### PR TITLE
Forcing Locale to be English to prevent Error

### DIFF
--- a/src/main/java/services/ParseCatalog.java
+++ b/src/main/java/services/ParseCatalog.java
@@ -27,7 +27,7 @@ import utils.UtilsKt;
 public class ParseCatalog implements Iterator<Course> {
   private Logger logger;
   private static DateTimeFormatter timeParser =
-      DateTimeFormat.forPattern("MM/dd/yyyy h:mma");
+      DateTimeFormat.forPattern("MM/dd/yyyy h:mma").withLocale(Locale.ENGLISH);
   private Iterator<Element> elements;
   private Element currentElement;
 


### PR DESCRIPTION
I was receiving error code from this file. After doing some research, I found the error was caused due to my system language is set in Chinese which has different DateTimeFormat. By setting Locale.ENGLISH, this error is gone ; )