### PR TITLE
Remove Async Http Client as a dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,9 +42,7 @@ dependencies {
     "org.postgresql:postgresql:42.2.12",
     "com.zaxxer:HikariCP:3.4.1",
 
-    // HTTP requests and HTML Parsing
-    "org.asynchttpclient:async-http-client-bom:2.10.5",
-    "org.asynchttpclient:async-http-client:2.10.5",
+    // HTML Parsing
     "org.jsoup:jsoup:1.15.3",
 
     // Command line arg parsing and progress bar

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,9 @@ dependencies {
     "org.postgresql:postgresql:42.2.12",
     "com.zaxxer:HikariCP:3.4.1",
 
-    // HTML Parsing
+    // HTTP requests and HTML Parsing
+    "org.asynchttpclient:async-http-client-bom:2.10.5",
+    "org.asynchttpclient:async-http-client:2.10.5",
     "org.jsoup:jsoup:1.15.3",
 
     // Command line arg parsing and progress bar

--- a/src/main/java/actions/ScrapeTerm.java
+++ b/src/main/java/actions/ScrapeTerm.java
@@ -1,20 +1,16 @@
 package actions;
 
-import static database.UpdateSchools.*;
 import static database.InsertCourses.*;
+import static database.UpdateSchools.*;
 import static utils.Nyu.*;
 
 import database.GetConnection;
-import java.io.IOException;
-import java.util.concurrent.*;
 import me.tongfei.progressbar.ProgressBar;
-import org.asynchttpclient.*;
 import scraping.PeopleSoftClassSearch;
 
 public class ScrapeTerm {
 
-  public static void scrapeTerm(Term term, boolean display)
-      throws IOException, ExecutionException, InterruptedException {
+  public static void scrapeTerm(Term term, boolean display) {
     if (!display) {
       scrapeTerm(term, null);
       return;
@@ -26,16 +22,13 @@ public class ScrapeTerm {
   }
 
   // @Note: bar is nullable
-  static void scrapeTerm(Term term, ProgressBar bar)
-      throws IOException, ExecutionException, InterruptedException {
-    try (AsyncHttpClient client = new DefaultAsyncHttpClient()) {
-      var search = new PeopleSoftClassSearch(client);
-      var termData = search.scrapeTerm(term, bar);
+  static void scrapeTerm(Term term, ProgressBar bar) {
+    var search = new PeopleSoftClassSearch();
+    var termData = search.scrapeTerm(term, bar);
 
-      GetConnection.withConnection(conn -> {
-        updateSchoolsForTerm(conn, term, termData.schools);
-        insertCourses(conn, term, termData.courses);
-      });
-    }
+    GetConnection.withConnection(conn -> {
+      updateSchoolsForTerm(conn, term, termData.schools);
+      insertCourses(conn, term, termData.courses);
+    });
   }
 }

--- a/src/main/java/cli/Scrape.java
+++ b/src/main/java/cli/Scrape.java
@@ -5,7 +5,6 @@ import static picocli.CommandLine.*;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import me.tongfei.progressbar.ProgressBar;
-import org.asynchttpclient.*;
 import org.slf4j.*;
 import picocli.CommandLine;
 import scraping.PeopleSoftClassSearch;

--- a/src/main/java/cli/Scrape.java
+++ b/src/main/java/cli/Scrape.java
@@ -35,8 +35,7 @@ public class Scrape implements Runnable {
            header = "Scrape the PeopleSoft Class Search",
            description = "Scrape the PeopleSoft Class Search for a term")
   public void
-  term(@Mixin Mixins.Term termMixin, @Mixin Mixins.OutputFile outputFileMixin)
-      throws IOException, ExecutionException, InterruptedException {
+  term(@Mixin Mixins.Term termMixin, @Mixin Mixins.OutputFile outputFileMixin) {
     long start = System.nanoTime();
 
     Nyu.Term term = termMixin.getTerm();

--- a/src/main/java/cli/Scrape.java
+++ b/src/main/java/cli/Scrape.java
@@ -41,9 +41,8 @@ public class Scrape implements Runnable {
     long start = System.nanoTime();
 
     Nyu.Term term = termMixin.getTerm();
-    try (AsyncHttpClient client = new DefaultAsyncHttpClient();
-         ProgressBar bar = new ProgressBar("Scrape", -1)) {
-      var search = new PeopleSoftClassSearch(client);
+    try (ProgressBar bar = new ProgressBar("Scrape", -1)) {
+      var search = new PeopleSoftClassSearch();
       var courses = search.scrapeTerm(term, bar);
       outputFileMixin.writeOutput(courses);
     }
@@ -64,16 +63,13 @@ public class Scrape implements Runnable {
           @Mixin Mixins.OutputFile outputFileMixin,
           @Parameters(index = "0", paramLabel = "SUBJECT",
                       description = "A subject code like MATH-UA")
-          String subject)
-      throws IOException, ExecutionException, InterruptedException {
+          String subject) {
     long start = System.nanoTime();
 
     Nyu.Term term = termMixin.getTerm();
-    try (AsyncHttpClient client = new DefaultAsyncHttpClient()) {
-      var search = new PeopleSoftClassSearch(client);
-      var courses = search.scrapeSubject(term, subject);
-      outputFileMixin.writeOutput(courses);
-    }
+    var search = new PeopleSoftClassSearch();
+    var courses = search.scrapeSubject(term, subject);
+    outputFileMixin.writeOutput(courses);
 
     long end = System.nanoTime();
     double duration = (end - start) / 1000000000.0;
@@ -88,16 +84,13 @@ public class Scrape implements Runnable {
            description = "Scrape the PeopleSoft Class Search for a term")
   public void
   schools(@Mixin Mixins.Term termMixin,
-          @Mixin Mixins.OutputFile outputFileMixin)
-      throws IOException, ExecutionException, InterruptedException {
+          @Mixin Mixins.OutputFile outputFileMixin) {
     long start = System.nanoTime();
 
     Nyu.Term term = termMixin.getTerm();
-    try (AsyncHttpClient client = new DefaultAsyncHttpClient()) {
-      var search = new PeopleSoftClassSearch(client);
-      var schools = search.scrapeSchools(term);
-      outputFileMixin.writeOutput(schools);
-    }
+    var search = new PeopleSoftClassSearch();
+    var schools = search.scrapeSchools(term);
+    outputFileMixin.writeOutput(schools);
 
     long end = System.nanoTime();
     double duration = (end - start) / 1000000000.0;

--- a/src/main/java/scraping/PeopleSoftClassSearch.java
+++ b/src/main/java/scraping/PeopleSoftClassSearch.java
@@ -14,7 +14,6 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.stream.Collectors;
 import me.tongfei.progressbar.ProgressBar;
-import org.asynchttpclient.AsyncHttpClient;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.*;
 import org.slf4j.*;

--- a/src/main/java/scraping/PeopleSoftClassSearch.java
+++ b/src/main/java/scraping/PeopleSoftClassSearch.java
@@ -95,7 +95,7 @@ public final class PeopleSoftClassSearch {
     var cookieHandler = new CookieManager();
     var builder = HttpClient.newBuilder();
 
-    this.client = builder.connectTimeout(Duration.of(30, ChronoUnit.DAYS))
+    this.client = builder.connectTimeout(Duration.of(30, ChronoUnit.SECONDS))
                       .cookieHandler(cookieHandler)
                       .build();
   }
@@ -353,7 +353,7 @@ public final class PeopleSoftClassSearch {
   static HttpRequest get(URI uri) {
     return HttpRequest.newBuilder()
         .uri(uri)
-        .timeout(Duration.of(30, ChronoUnit.DAYS))
+        .timeout(Duration.of(30, ChronoUnit.SECONDS))
         .setHeader("User-Agent", USER_AGENT)
         .setHeader("Content-Type", "application/x-www-form-urlencoded")
         .GET()
@@ -365,7 +365,7 @@ public final class PeopleSoftClassSearch {
 
     return HttpRequest.newBuilder()
         .uri(uri)
-        .timeout(Duration.of(30, ChronoUnit.DAYS))
+        .timeout(Duration.of(30, ChronoUnit.SECONDS))
         .setHeader("User-Agent", USER_AGENT)
         .setHeader("Content-Type", "application/x-www-form-urlencoded")
         .POST(HttpRequest.BodyPublishers.ofString(s))


### PR DESCRIPTION
Completes #126

- Switch to using `HttpClient` API from Java 11
- Remove `async-http-client` as a dependency
- Remove `throws` declarations that are redundant
- JAR size is now `12M`, down from `15M`

Second order benefits:
- Scraper can be more easily parallelized, by just creating more clients. Previous client would create a new thread-pool for each new client, which is no bueno.
- Scraper can more easily integrate with Java Loom down the road
- Compiles are faster