### PR TITLE
Use Standard ReDoc index.html instead of webjar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,8 +58,6 @@ dependencies {
     "io.javalin:javalin:5.1.1",
     // for /openapi route with JSON scheme
     "io.javalin.community.openapi:javalin-openapi-plugin:5.1.0",
-    // for ReDoc UI
-    "io.javalin.community.openapi:javalin-redoc-plugin:5.1.0",
   )
 }
 

--- a/src/main/java/api/App.java
+++ b/src/main/java/api/App.java
@@ -7,7 +7,6 @@ import io.javalin.http.*;
 import io.javalin.http.staticfiles.Location;
 import io.javalin.openapi.OpenApiInfo;
 import io.javalin.openapi.plugin.*;
-import io.javalin.openapi.plugin.redoc.*;
 import java.io.*;
 import org.slf4j.*;
 

--- a/src/main/java/api/App.java
+++ b/src/main/java/api/App.java
@@ -80,17 +80,25 @@ public class App {
       var openApiConfig = new OpenApiConfiguration();
       openApiConfig.setInfo(info);
       openApiConfig.setDocumentationPath(jsonPath);
-      var reDocConfig = new ReDocConfiguration();
-      reDocConfig.setDocumentationPath(jsonPath);
-      reDocConfig.setWebJarPath("/api/webjars");
-      reDocConfig.setUiPath(htmlPath);
+      // var reDocConfig = new ReDocConfiguration();
+      // reDocConfig.setDocumentationPath(jsonPath);
+      // reDocConfig.setWebJarPath("/api/webjars");
+      // reDocConfig.setUiPath(htmlPath);
       config.plugins.register(new OpenApiPlugin(openApiConfig));
-      config.plugins.register(new ReDocPlugin(reDocConfig));
+      // config.plugins.register(new ReDocPlugin(reDocConfig));
 
       // Add static files for the NextJS UI
       config.staticFiles.add(staticFiles -> {
         staticFiles.hostedPath = "/";
-        staticFiles.directory = "/next/";
+        staticFiles.directory = "/next";
+        staticFiles.location = Location.CLASSPATH;
+        staticFiles.precompress = false;
+      });
+
+      // Static files for the ReDoc API Docs
+      config.staticFiles.add(staticFiles -> {
+        staticFiles.hostedPath = "/api";
+        staticFiles.directory = "/api";
         staticFiles.location = Location.CLASSPATH;
         staticFiles.precompress = false;
       });

--- a/src/main/java/api/App.java
+++ b/src/main/java/api/App.java
@@ -71,32 +71,20 @@ public class App {
       info.setTitle("Schedge");
       info.setDescription(description);
 
-      // Redoc uses webjars to do... something
-      config.staticFiles.enableWebjars();
-
-      // Set up OpenAPI + Redoc
-      var htmlPath = "/api";
       var jsonPath = "/api/swagger.json";
       var openApiConfig = new OpenApiConfiguration();
       openApiConfig.setInfo(info);
       openApiConfig.setDocumentationPath(jsonPath);
-      // var reDocConfig = new ReDocConfiguration();
-      // reDocConfig.setDocumentationPath(jsonPath);
-      // reDocConfig.setWebJarPath("/api/webjars");
-      // reDocConfig.setUiPath(htmlPath);
       config.plugins.register(new OpenApiPlugin(openApiConfig));
-      // config.plugins.register(new ReDocPlugin(reDocConfig));
 
-      // Add static files for the NextJS UI
-      config.staticFiles.add(staticFiles -> {
+      config.staticFiles.add(staticFiles -> { // NextJS UI
         staticFiles.hostedPath = "/";
         staticFiles.directory = "/next";
         staticFiles.location = Location.CLASSPATH;
         staticFiles.precompress = false;
       });
 
-      // Static files for the ReDoc API Docs
-      config.staticFiles.add(staticFiles -> {
+      config.staticFiles.add(staticFiles -> { // ReDoc API Docs
         staticFiles.hostedPath = "/api";
         staticFiles.directory = "/api";
         staticFiles.location = Location.CLASSPATH;

--- a/src/main/resources/api/index.html
+++ b/src/main/resources/api/index.html
@@ -22,7 +22,7 @@
     </style>
   </head>
   <body>
-    <redoc spec-url="/swagger.json"></redoc>
+    <redoc spec-url="/api/swagger.json"></redoc>
     <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Completes #159

- Removes dependency on OpenAPI WebJar crap
- Drops JAR size from `24M` down to `15M`