### PR TITLE
Improve Term CLI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     "org.jsoup:jsoup:1.15.3",
 
     // Command line arg parsing and progress bar
-    "info.picocli:picocli:4.1.4",
+    "info.picocli:picocli:4.7.0",
     "me.tongfei:progressbar:0.8.1",
 
     // JSON

--- a/src/main/java/actions/ScrapeTerm.java
+++ b/src/main/java/actions/ScrapeTerm.java
@@ -16,7 +16,7 @@ public class ScrapeTerm {
       return;
     }
 
-    try (ProgressBar bar = new ProgressBar("Scraper", -1)) {
+    try (ProgressBar bar = new ProgressBar("Scrape " + term.json(), -1)) {
       scrapeTerm(term, bar);
     }
   }

--- a/src/main/java/api/v1/CoursesEndpoint.java
+++ b/src/main/java/api/v1/CoursesEndpoint.java
@@ -45,7 +45,7 @@ public final class CoursesEndpoint extends App.Endpoint {
   public Object
   handleEndpoint(Context ctx) {
     String termString = ctx.pathParam("term");
-    var term = SchoolInfoEndpoint.parseTerm(termString);
+    var term = Term.fromString(termString);
 
     var subject = ctx.pathParam("subject").toUpperCase();
 

--- a/src/main/java/api/v1/GenerateScheduleEndpoint.java
+++ b/src/main/java/api/v1/GenerateScheduleEndpoint.java
@@ -7,6 +7,8 @@ import database.*;
 import database.models.AugmentedMeeting;
 import io.javalin.http.Context;
 import io.javalin.openapi.*;
+import utils.*;
+
 import java.util.ArrayList;
 
 public final class GenerateScheduleEndpoint extends App.Endpoint {
@@ -41,7 +43,7 @@ public final class GenerateScheduleEndpoint extends App.Endpoint {
   )
   public Object handleEndpoint(Context ctx) {
     String termString = ctx.pathParam("term");
-    var term = SchoolInfoEndpoint.parseTerm(termString);
+    var term = Nyu.Term.fromString(termString);
 
     String regNumsString = ctx.queryParam("registrationNumbers");
     if (regNumsString == null) {

--- a/src/main/java/api/v1/SchoolInfoEndpoint.java
+++ b/src/main/java/api/v1/SchoolInfoEndpoint.java
@@ -22,19 +22,6 @@ public final class SchoolInfoEndpoint extends App.Endpoint {
       + "like sp2021 for Spring 2021. Use 'su' for Summer, 'sp' "
       + "for Spring, 'fa' for Fall, and 'ja' for January/JTerm";
 
-  public static Term parseTerm(String termString) {
-    if (termString.contentEquals("current")) {
-      return Term.getCurrentTerm();
-    }
-
-    if (termString.contentEquals("next")) {
-      return Term.getCurrentTerm().nextTerm();
-    }
-
-    int year = Integer.parseInt(termString.substring(2));
-    return new Term(termString.substring(0, 2), year);
-  }
-
   @OpenApi(
       path = "/api/schools/{term}", methods = HttpMethod.GET,
       summary = "School Info",
@@ -60,7 +47,7 @@ public final class SchoolInfoEndpoint extends App.Endpoint {
       })
   public Object
   handleEndpoint(Context ctx) {
-    Term term = parseTerm(ctx.pathParam("term"));
+    Term term = Term.fromString(ctx.pathParam("term"));
 
     Info info = new Info();
     info.term = term;

--- a/src/main/java/api/v1/SearchEndpoint.java
+++ b/src/main/java/api/v1/SearchEndpoint.java
@@ -47,7 +47,7 @@ public final class SearchEndpoint extends App.Endpoint {
   public Object
   handleEndpoint(Context ctx) {
     String termString = ctx.pathParam("term");
-    var term = SchoolInfoEndpoint.parseTerm(termString);
+    var term = Nyu.Term.fromString(termString);
 
     String args = ctx.queryParam("query");
     if (args == null) {

--- a/src/main/java/cli/Database.java
+++ b/src/main/java/cli/Database.java
@@ -7,7 +7,6 @@ import actions.ScrapeTerm;
 import database.GetConnection;
 import database.InsertCourses;
 import database.UpdateSchools;
-import java.io.*;
 import org.slf4j.*;
 import picocli.CommandLine;
 import scraping.PeopleSoftClassSearch;
@@ -33,7 +32,7 @@ public class Database implements Runnable {
   public void scrapeSchools(@Mixin Mixins.Term termMixin) {
     long start = System.nanoTime();
 
-    var term = termMixin.getTerm();
+    var term = termMixin.term;
 
     var schools = PeopleSoftClassSearch.scrapeSchools(term);
 
@@ -46,12 +45,13 @@ public class Database implements Runnable {
   }
 
   @Command(name = "scrape-term", description = "Scrape all data for a term")
-  public void scrapeTerm(@Mixin Mixins.Term termMixin) {
+  public void scrapeTerm(@Parameters(paramLabel = "TERMS", description = "Terms to scrape, e.g. fa2020, ja2020, sp2020, su2020", converter = Mixins.TermConverter.class) Term[] terms) {
     long start = System.nanoTime();
 
-    var term = termMixin.getTerm();
+    for (var term : terms) {
+      ScrapeTerm.scrapeTerm(term, true);
+    }
 
-    ScrapeTerm.scrapeTerm(term, true);
     GetConnection.close();
 
     long end = System.nanoTime();
@@ -66,7 +66,7 @@ public class Database implements Runnable {
   populate(@Mixin Mixins.Term termMixin) {
     long start = System.nanoTime();
 
-    Term term = termMixin.getTerm();
+    Term term = termMixin.term;
     GetConnection.withConnection(conn -> {
       var courses = ScrapeSchedge.scrapeFromSchedge(term);
 

--- a/src/main/java/cli/Mixins.java
+++ b/src/main/java/cli/Mixins.java
@@ -57,49 +57,16 @@ public final class Mixins {
     @Spec private CommandLine.Model.CommandSpec spec;
 
     @Option(names = "--term",
-            description = "Term is the shortcut for year and semester. "
-                          + "To get term value, take year - 1900 then append \n"
-                          + "ja = 2, sp = 4, su = 6 or fa = 8.\n Eg: "
-                          + "Fall 2020 = (2020 - 1900) + 4 = 120 + 4 = 1204")
-    private Integer termId;
+            description = "example: fa2020, where: fa=Fall, ja=January, sp=Spring, su=Summer", converter = TermConverter.class)
+    public Nyu.Term term;
+  }
 
-    @Option(names = "--semester", description = "semester: ja, sp, su, or fa")
-    private String semester;
+  public static class TermConverter implements ITypeConverter<Nyu.Term> {
+    public TermConverter() {}
 
-    @Option(names = "--year", description = "year to scrape from")
-    private Integer year;
-
-    @Option(names = {"-h", "--help"}, usageHelp = true,
-            description = "display a help message")
-    boolean displayHelp;
-
-    public Nyu.Term getTermAllowNull() {
-      if (termId != null && (semester != null || year != null)) {
-        throw new CommandLine.MutuallyExclusiveArgsException(
-            spec.commandLine(),
-            "--term and --semester/--year are mutually exclusive");
-      } else if (termId == null && semester == null && year == null) {
-        return null;
-      } else if (termId == null) {
-        if (semester == null || year == null) {
-          throw new CommandLine.ParameterException(
-              spec.commandLine(), "Must provide both --semester AND --year");
-        }
-        return new Nyu.Term(semester, year);
-      } else {
-        return Nyu.Term.fromId(termId);
-      }
-    }
-
-    public Nyu.Term getTerm() {
-      Nyu.Term t = getTermAllowNull();
-      if (t == null) {
-        throw new CommandLine.ParameterException(
-            spec.commandLine(),
-            "Must provide at least one: --term   OR   --semester AND --year");
-      } else {
-        return t;
-      }
+    @Override
+    public Nyu.Term convert(String value) {
+      return Nyu.Term.fromString(value);
     }
   }
 }

--- a/src/main/java/cli/Scrape.java
+++ b/src/main/java/cli/Scrape.java
@@ -38,7 +38,7 @@ public class Scrape implements Runnable {
   term(@Mixin Mixins.Term termMixin, @Mixin Mixins.OutputFile outputFileMixin) {
     long start = System.nanoTime();
 
-    Nyu.Term term = termMixin.getTerm();
+    Nyu.Term term = termMixin.term;
     try (ProgressBar bar = new ProgressBar("Scrape", -1)) {
       var courses = PeopleSoftClassSearch.scrapeTerm(term, bar);
       outputFileMixin.writeOutput(courses);
@@ -63,7 +63,7 @@ public class Scrape implements Runnable {
           String subject) {
     long start = System.nanoTime();
 
-    Nyu.Term term = termMixin.getTerm();
+    Nyu.Term term = termMixin.term;
     var courses = PeopleSoftClassSearch.scrapeSubject(term, subject);
     outputFileMixin.writeOutput(courses);
 
@@ -83,7 +83,7 @@ public class Scrape implements Runnable {
           @Mixin Mixins.OutputFile outputFileMixin) {
     long start = System.nanoTime();
 
-    Nyu.Term term = termMixin.getTerm();
+    Nyu.Term term = termMixin.term;
     var schools = PeopleSoftClassSearch.scrapeSchools(term);
     outputFileMixin.writeOutput(schools);
 

--- a/src/main/java/utils/Nyu.java
+++ b/src/main/java/utils/Nyu.java
@@ -303,7 +303,6 @@ public final class Nyu {
   }
 
   public static final class Term {
-
     public final Nyu.Semester semester;
     public final int year;
 
@@ -322,6 +321,19 @@ public final class Nyu {
       Nyu.Semester semester = Nyu.Semester.values()[(id % 10) / 2 - 1];
 
       return new Term(semester, id / 10 + 1900);
+    }
+
+    public static Term fromString(String termString) {
+      if (termString.contentEquals("current")) {
+        return getCurrentTerm();
+      }
+
+      if (termString.contentEquals("next")) {
+        return getCurrentTerm().nextTerm();
+      }
+
+      int year = Integer.parseInt(termString.substring(2));
+      return new Term(termString.substring(0, 2), year);
     }
 
     // @TODO Make this more accurate
@@ -466,24 +478,16 @@ public final class Nyu {
 
       var nyc = ZoneId.of("America/New_York");
       var buenosAires = ZoneId.of("America/Argentina/Buenos_Aires");
-      var berlin = ZoneId.of("Europe/Berlin");
       var losAngeles = ZoneId.of("America/Los_Angeles");
 
       var campusList = new Campus[] {
-          new Campus("Dublin", ZoneId.of("Europe/Dublin")),
           new Campus("NYU London (Global)", ZoneId.of("Europe/London")),
           new Campus("NYU Paris (Global)", ZoneId.of("Europe/Paris")),
           new Campus("NYU Florence (Global)", ZoneId.of("Europe/Rome")),
-          new Campus("NYU Berlin (Global)", berlin),
-          new Campus("Berlin", berlin),
-          new Campus("Germany", berlin),
+          new Campus("NYU Berlin (Global)", ZoneId.of("Europe/Berlin")),
           new Campus("NYU Madrid (Global)", ZoneId.of("Europe/Madrid")),
-          new Campus("Madrid", ZoneId.of("Europe/Madrid")),
           new Campus("NYU Prague (Global)", ZoneId.of("Europe/Prague")),
-          new Campus("Prague", ZoneId.of("Europe/Prague")),
           new Campus("Athens", ZoneId.of("Europe/Athens")),
-          new Campus("Greece", ZoneId.of("Europe/Athens")),
-          new Campus("Sweden", ZoneId.of("Europe/Stockholm")),
 
           new Campus("NYU Abu Dhabi (Global)", ZoneId.of("Asia/Dubai")),
           new Campus("Abu Dhabi", ZoneId.of("Asia/Dubai")),
@@ -494,17 +498,8 @@ public final class Nyu {
           new Campus("NYU Sydney (Global)", ZoneId.of("Australia/Sydney")),
 
           new Campus("NYU Accra (Global)", ZoneId.of("Africa/Accra")),
-
           new Campus("NYU Buenos Aires (Global)", buenosAires),
           new Campus("NYU Los Angeles (Global)", losAngeles),
-          new Campus("Colombia", ZoneId.of("America/Bogota")),
-
-          // @Note: Brazil has 3 time zones; I have no idea which one is the
-          // right one, but the primary time zone of Brazil is Brazil/East so
-          // this is a best-effort choice.
-          //
-          //                              - Albert Liu, Nov 10, 2022 Thu 22:09
-          new Campus("Brazil", ZoneId.of("Brazil/East")),
 
           new Campus("Off Campus", nyc),
           new Campus("Online", nyc),
@@ -519,7 +514,6 @@ public final class Nyu {
           new Campus("ePoly", nyc),
           new Campus("Medical Center Long Island", nyc),
           new Campus("NYU New York (Global)", nyc),
-          new Campus("Wallkill Correctional Facility", nyc),
 
           new Campus("Woolworth Bldg.-15 Barclay St", nyc),
           new Campus("Grad Stern at Purchase", nyc),
@@ -529,7 +523,6 @@ public final class Nyu {
           new Campus("Inst. of Fine Arts", nyc),
           new Campus("Medical Center", nyc),
           new Campus("NYU Washington DC (Global)", nyc),
-          new Campus("Washington, DC", nyc),
           new Campus("Brooklyn Campus", nyc),
           new Campus("Washington Square", nyc),
       };
@@ -545,7 +538,7 @@ public final class Nyu {
       var campus = campuses.get(name);
       if (campus == null) {
         // throw new IllegalArgumentException("Bad campus: " + campus);
-        System.err.println("\nBad campus: " + name);
+        System.err.println("Bad campus: " + name);
         return ZoneId.of("America/New_York");
       }
 

--- a/src/main/java/utils/Nyu.java
+++ b/src/main/java/utils/Nyu.java
@@ -303,6 +303,7 @@ public final class Nyu {
   }
 
   public static final class Term {
+
     public final Nyu.Semester semester;
     public final int year;
 
@@ -478,16 +479,24 @@ public final class Nyu {
 
       var nyc = ZoneId.of("America/New_York");
       var buenosAires = ZoneId.of("America/Argentina/Buenos_Aires");
+      var berlin = ZoneId.of("Europe/Berlin");
       var losAngeles = ZoneId.of("America/Los_Angeles");
 
       var campusList = new Campus[] {
+          new Campus("Dublin", ZoneId.of("Europe/Dublin")),
           new Campus("NYU London (Global)", ZoneId.of("Europe/London")),
           new Campus("NYU Paris (Global)", ZoneId.of("Europe/Paris")),
           new Campus("NYU Florence (Global)", ZoneId.of("Europe/Rome")),
-          new Campus("NYU Berlin (Global)", ZoneId.of("Europe/Berlin")),
+          new Campus("NYU Berlin (Global)", berlin),
+          new Campus("Berlin", berlin),
+          new Campus("Germany", berlin),
           new Campus("NYU Madrid (Global)", ZoneId.of("Europe/Madrid")),
+          new Campus("Madrid", ZoneId.of("Europe/Madrid")),
           new Campus("NYU Prague (Global)", ZoneId.of("Europe/Prague")),
+          new Campus("Prague", ZoneId.of("Europe/Prague")),
           new Campus("Athens", ZoneId.of("Europe/Athens")),
+          new Campus("Greece", ZoneId.of("Europe/Athens")),
+          new Campus("Sweden", ZoneId.of("Europe/Stockholm")),
 
           new Campus("NYU Abu Dhabi (Global)", ZoneId.of("Asia/Dubai")),
           new Campus("Abu Dhabi", ZoneId.of("Asia/Dubai")),
@@ -498,8 +507,17 @@ public final class Nyu {
           new Campus("NYU Sydney (Global)", ZoneId.of("Australia/Sydney")),
 
           new Campus("NYU Accra (Global)", ZoneId.of("Africa/Accra")),
+
           new Campus("NYU Buenos Aires (Global)", buenosAires),
           new Campus("NYU Los Angeles (Global)", losAngeles),
+          new Campus("Colombia", ZoneId.of("America/Bogota")),
+
+          // @Note: Brazil has 3 time zones; I have no idea which one is the
+          // right one, but the primary time zone of Brazil is Brazil/East so
+          // this is a best-effort choice.
+          //
+          //                              - Albert Liu, Nov 10, 2022 Thu 22:09
+          new Campus("Brazil", ZoneId.of("Brazil/East")),
 
           new Campus("Off Campus", nyc),
           new Campus("Online", nyc),
@@ -514,6 +532,7 @@ public final class Nyu {
           new Campus("ePoly", nyc),
           new Campus("Medical Center Long Island", nyc),
           new Campus("NYU New York (Global)", nyc),
+          new Campus("Wallkill Correctional Facility", nyc),
 
           new Campus("Woolworth Bldg.-15 Barclay St", nyc),
           new Campus("Grad Stern at Purchase", nyc),
@@ -523,6 +542,7 @@ public final class Nyu {
           new Campus("Inst. of Fine Arts", nyc),
           new Campus("Medical Center", nyc),
           new Campus("NYU Washington DC (Global)", nyc),
+          new Campus("Washington, DC", nyc),
           new Campus("Brooklyn Campus", nyc),
           new Campus("Washington Square", nyc),
       };
@@ -538,7 +558,7 @@ public final class Nyu {
       var campus = campuses.get(name);
       if (campus == null) {
         // throw new IllegalArgumentException("Bad campus: " + campus);
-        System.err.println("Bad campus: " + name);
+        System.err.println("\nBad campus: " + name);
         return ZoneId.of("America/New_York");
       }
 


### PR DESCRIPTION
- Switches `Mixins.Term` to use `fa2020` format
- `schedge db scrape-term` now accepts `fa2020` format as positional parameter
- `schedge db scrape-term` can accept multiple terms
- Move `parseTerm` from endpoint into `Nyu.Term` class