### PR TITLE
Clear previous data from term

### DIFF
--- a/src/main/java/actions/ScrapeTerm.java
+++ b/src/main/java/actions/ScrapeTerm.java
@@ -24,6 +24,8 @@ public class ScrapeTerm {
   // @Note: bar is nullable
   static void scrapeTerm(Term term, ProgressBar bar) {
     GetConnection.withConnection(conn -> {
+      clearPrevious(conn, term);
+
       var termData = PeopleSoftClassSearch.scrapeTerm(term, bar);
       updateSchoolsForTerm(conn, term, termData.getSchools());
 


### PR DESCRIPTION
- Adds a call to `clearPrevious` so that new scrapes don't duplicate data