### PR TITLE
Switch to `eclipse-temurin`

### DIFF
--- a/src/build/docker/Dockerfile
+++ b/src/build/docker/Dockerfile
@@ -15,8 +15,27 @@
 #   ```
 #
 #                               - Albert Liu, Nov 06, 2022 Sun 13:21
-FROM openjdk:17.0.2-jdk-slim-buster
+# FROM openjdk:17.0.2-jdk-slim-buster
+# Example of custom Java runtime using jlink in a multi-stage container build
+FROM eclipse-temurin:11-alpine as jre-build
 
+# Create a custom Java runtime
+RUN $JAVA_HOME/bin/jlink \
+        --add-modules java.se \
+        --add-modules jdk.zipfs \
+        --strip-debug \
+        --no-man-pages \
+        --no-header-files \
+        --compress=2 \
+        --output /javaruntime
+
+# Define your base image
+FROM alpine:3.17
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH "${JAVA_HOME}/bin:${PATH}"
+COPY --from=jre-build /javaruntime $JAVA_HOME
+
+# Continue with your application deployment
 WORKDIR "/home/user"
 
 EXPOSE 4358

--- a/src/build/docker/Dockerfile
+++ b/src/build/docker/Dockerfile
@@ -15,7 +15,6 @@
 #                               - Albert Liu, Nov 06, 2022 Sun 13:21
 FROM eclipse-temurin:19-jre-alpine
 
-# Continue with your application deployment
 WORKDIR "/home/user"
 
 EXPOSE 4358

--- a/src/build/docker/Dockerfile
+++ b/src/build/docker/Dockerfile
@@ -1,5 +1,3 @@
-# FROM openjdk:8u212-jre-alpine3.9
-
 # @Note: Can use the following to prevent Docker's "load metadata"
 # bullshit: https://stackoverflow.com/a/70483395
 #
@@ -7,33 +5,15 @@
 #
 #   ```
 #   # Do this BEFORE losing internet connection
-#   docker pull openjdk:17.0.2-jdk-slim-buster
-#   docker tag openjdk:17.0.2-jdk-slim-buster schedge/base
+#   docker pull eclipse-temurin:19-jre-alpine
+#   docker tag eclipse-temurin:19-jre-alpine schedge/base
 #
-#   # in Dockerfile
+#   # in Dockerfile, edit the line below to be:
 #   FROM schedge/base
 #   ```
 #
 #                               - Albert Liu, Nov 06, 2022 Sun 13:21
-# FROM openjdk:17.0.2-jdk-slim-buster
-# Example of custom Java runtime using jlink in a multi-stage container build
-FROM eclipse-temurin:11-alpine as jre-build
-
-# Create a custom Java runtime
-RUN $JAVA_HOME/bin/jlink \
-        --add-modules java.se \
-        --add-modules jdk.zipfs \
-        --strip-debug \
-        --no-man-pages \
-        --no-header-files \
-        --compress=2 \
-        --output /javaruntime
-
-# Define your base image
-FROM alpine:3.17
-ENV JAVA_HOME=/opt/java/openjdk
-ENV PATH "${JAVA_HOME}/bin:${PATH}"
-COPY --from=jre-build /javaruntime $JAVA_HOME
+FROM eclipse-temurin:19-jre-alpine
 
 # Continue with your application deployment
 WORKDIR "/home/user"


### PR DESCRIPTION
- Switch dockerfile base to `eclipse-temurin`
- In the process, using JRE 19 instead of 17, anticipating a transition into using Project Loom