### PR TITLE
Rename ScrapeSchedge and ScrapeSchedge2

### DIFF
--- a/src/main/java/actions/CopyTermFromProduction.java
+++ b/src/main/java/actions/CopyTermFromProduction.java
@@ -19,7 +19,7 @@ public class CopyTermFromProduction {
 
         GetConnection.withConnection(conn -> {
             long start = System.nanoTime();
-            var result = ScrapeSchedge2.scrapeFromSchedge(term);
+            var result = ScrapeSchedgeV2.scrapeFromSchedge(term);
 
             long end = System.nanoTime();
             double duration = (end - start) / 1000000000.0;

--- a/src/main/java/scraping/ScrapeSchedgeV1.java
+++ b/src/main/java/scraping/ScrapeSchedgeV1.java
@@ -9,13 +9,9 @@ import java.util.concurrent.*;
 import org.slf4j.*;
 import utils.*;
 
-public final class ScrapeSchedge {
-  private static Logger logger =
-      LoggerFactory.getLogger("scraping.ScrapeSchedge");
+public final class ScrapeSchedgeV1 {
+  static Logger logger = LoggerFactory.getLogger("scraping.ScrapeSchedgeV1");
 
-  // @TODO this will eventually scrape directly from the new API instead of
-  // the old one
-  //                        - Albert Liu, Jan 25, 2022 Tue 18:32 EST
   private static final String SCHEDGE_URL = "https://schedge.a1liu.com/";
 
   public static List<Course> scrapeFromSchedge(Term term) {

--- a/src/main/java/scraping/ScrapeSchedgeV2.java
+++ b/src/main/java/scraping/ScrapeSchedgeV2.java
@@ -12,7 +12,7 @@ import java.util.concurrent.*;
 import org.slf4j.*;
 import utils.*;
 
-public final class ScrapeSchedge2 {
+public final class ScrapeSchedgeV2 {
   private static Logger logger =
       LoggerFactory.getLogger("scraping.ScrapeSchedge2");
 


### PR DESCRIPTION
Using `V1` and `V2` suffixes to differentiate them