### PR TITLE
Add Test runs on CI for PR branches and `main`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '19'
           distribution: 'adopt'
           cache: 'gradle'
 

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: read
 
-    steps:        
+    steps:
       - name: Install Websocat
         run: wget https://github.com/vi/websocat/releases/download/v1.11.0/websocat.x86_64-unknown-linux-musl -O ./websocat
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,11 +54,13 @@ jobs:
     - name: Build JAR file
       run: |
         yarn gradle jar
-        mkdir -p /app
-        mv ./.build/libs/schedge.jar /app/schedge.jar
 
+    # Command lifted from `src/build/docker/entrypoint.sh`
     - name: Scrape terms
-      run: ./src/build/docker/entrypoint.sh db populate --v2 ja2021
+      run: >
+        java -Xmx1G -Djdk.httpclient.allowRestrictedHeaders=host,connection
+        -jar .build/libs/schedge.jar
+        db populate --v2 ja2021
 
     - name: Test Code
       run: yarn test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,11 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
-    container: ubuntu:22.04
+        # Maps tcp port 5432 on service container to the host
+        ports:
+          - 5432:5432
+
+    # container: ubuntu:22.04
     env:
       DB_USERNAME: postgres
       DB_PASSWORD: postgres

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,8 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+
+    container: ubuntu:22.04
     env:
       DB_USERNAME: postgres
       DB_PASSWORD: postgres

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,4 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
-
-name: Java CI with Gradle
+name: Test Java Code
 
 on:
   push:
@@ -20,6 +13,25 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+
+    # Service containers to run with `container-job`
+    services:
+      # Label used to access the service container
+      postgres:
+        # Docker Hub image
+        image: postgres:14.1-alpine
+
+        # Provide the password for postgres
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
     - name: Checkout Project
@@ -38,6 +50,9 @@ jobs:
         java-version: '11'
         distribution: 'temurin'
         cache: 'gradle'
-    
+
+    - name: Scrape terms
+      run: yarn schedge db populate --v2 --term=ja2020
+
     - name: Test Code
       run: yarn test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
       run: >
         java -Xmx1G -Djdk.httpclient.allowRestrictedHeaders=host,connection
         -jar .build/libs/schedge.jar
-        db populate --v2 ja2021
+        db populate --v2 sp2021 fa2022 ja2022 sp2023
 
     - name: Test Code
       run: yarn test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,43 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
+
+name: Java CI with Gradle
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Project
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+
+    - name: Set up Node + Yarn
+      uses: actions/setup-node@v3
+      with:
+        cache: 'yarn'
+    
+    - name: Set up Java
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: 'gradle'
+    
+    - name: Test Code
+      run: yarn test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
     env:
       DB_USERNAME: postgres
       DB_PASSWORD: postgres
-      JDBC_URL: jdbc:postgresql://postgres/postgres
+      JDBC_URL: jdbc:postgresql://localhost:5432/postgres
 
     steps:
     - name: Checkout Project

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,13 +47,13 @@ jobs:
     - name: Set up Java
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: '19'
         distribution: 'temurin'
         cache: 'gradle'
 
     - name: Build JAR file
-      run: >
-        yarn jar
+      run: |
+        yarn gradle jar
         mkdir -p /app
         mv ./.build/libs/schedge.jar /app/schedge.jar
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,10 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+    env:
+      DB_USERNAME: postgres
+      DB_PASSWORD: postgres
+      JDBC_URL: jdbc:postgresql://postgres/postgres
 
     steps:
     - name: Checkout Project

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
       uses: actions/setup-node@v3
       with:
         cache: 'yarn'
-    
+
     - name: Set up Java
       uses: actions/setup-java@v3
       with:
@@ -51,8 +51,14 @@ jobs:
         distribution: 'temurin'
         cache: 'gradle'
 
+    - name: Build JAR file
+      run: >
+        yarn jar
+        mkdir -p /app
+        mv ./.build/libs/schedge.jar /app/schedge.jar
+
     - name: Scrape terms
-      run: yarn schedge db populate --v2 --term=ja2020
+      run: ./src/build/docker/entrypoint.sh db populate --v2 ja2021
 
     - name: Test Code
       run: yarn test

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -59,7 +59,7 @@ You'll need to install a few applications to contribute to this project:
 - `yarn stop`: Close the servers when development is done
 
 ## Useful Commands
-- `yarn schedge db populate --v2 --term=sp2022` -
+- `yarn schedge db populate --v2 sp2022` -
   Populate your database with data from production
 - `docker-compose postgres psql --dbname=postgres --host=localhost --port=5432 --username=postgres` -
   Run `psql` on the local database

--- a/src/main/java/api/App.java
+++ b/src/main/java/api/App.java
@@ -15,7 +15,8 @@ public class App {
   private static final Logger logger = LoggerFactory.getLogger("api.App");
 
   static {
-    GetConnection.withConnection(conn -> Migrations.runMigrations(conn));
+    // Ensure that the connection gets instantiated during startup
+    GetConnection.withConnection(conn -> {});
   }
 
   public abstract static class Endpoint implements Handler {

--- a/src/main/java/cli/Database.java
+++ b/src/main/java/cli/Database.java
@@ -88,11 +88,11 @@ public class Database implements Runnable {
     long start = System.nanoTime();
 
     var terms = termMixin.terms;
-
+    var version = useV2 ? SchedgeVersion.V2 : SchedgeVersion.V1;
     for (var term : terms) {
-      copyTermFromProduction(useV2 ? SchedgeVersion.V2 : SchedgeVersion.V1,
-                             term);
+      copyTermFromProduction(version, term);
     }
+
     GetConnection.close();
 
     long end = System.nanoTime();

--- a/src/main/java/cli/Database.java
+++ b/src/main/java/cli/Database.java
@@ -28,7 +28,7 @@ public class Database implements Runnable {
   }
 
   @Command(name = "scrape-schools", description = "Scrape schools for a term")
-  public void scrapeSchools(@Mixin Mixins.Term termMixin) {
+  public void scrapeSchools(@Mixin Mixins.TermOption termMixin) {
     long start = System.nanoTime();
 
     var term = termMixin.term;
@@ -44,14 +44,11 @@ public class Database implements Runnable {
   }
 
   @Command(name = "scrape-term", description = "Scrape all data for a term")
-  public void scrapeTerm(@Parameters(
-      paramLabel = "TERMS",
-      description = "Terms to scrape, e.g. fa2020, ja2020, sp2020, su2020",
-      converter = Mixins.TermConverter.class) Term[] terms) {
+  public void scrapeTerm(@Mixin Mixins.TermArgument termMixin) {
     long start = System.nanoTime();
 
     GetConnection.withConnection(conn -> {
-      for (var term : terms) {
+      for (var term : termMixin.terms) {
         try (ProgressBar bar = new ProgressBar("Scrape " + term.json(), -1)) {
           ScrapeTerm.scrapeTerm(conn, term, e -> {
             switch (e.kind) {
@@ -85,13 +82,17 @@ public class Database implements Runnable {
       description = "Populate the database by scraping the existing production "
                     + "Schedge instance.\n")
   public void
-  populate(@Mixin Mixins.Term termMixin,
+  populate(@Mixin Mixins.TermArgument termMixin,
            @Option(names = {"--v2"},
                    description = "scrape v2 instead of v1") boolean useV2) {
     long start = System.nanoTime();
 
-    Term term = termMixin.term;
-    copyTermFromProduction(useV2 ? SchedgeVersion.V2 : SchedgeVersion.V1, term);
+    var terms = termMixin.terms;
+
+    for (var term : terms) {
+      copyTermFromProduction(useV2 ? SchedgeVersion.V2 : SchedgeVersion.V1,
+                             term);
+    }
     GetConnection.close();
 
     long end = System.nanoTime();

--- a/src/main/java/cli/Main.java
+++ b/src/main/java/cli/Main.java
@@ -2,6 +2,7 @@ package cli;
 
 import static picocli.CommandLine.*;
 
+import utils.Nyu;
 import api.App;
 import picocli.CommandLine;
 
@@ -20,6 +21,7 @@ public class Main implements Runnable {
     new CommandLine(new Main())
         .addSubcommand("scrape", new CommandLine(new cli.Scrape()))
         .addSubcommand("db", new CommandLine(new cli.Database()))
+        .registerConverter(Nyu.Term.class, new Mixins.TermConverter())
         .execute(args);
   }
 

--- a/src/main/java/cli/Mixins.java
+++ b/src/main/java/cli/Mixins.java
@@ -2,7 +2,6 @@ package cli;
 
 import static picocli.CommandLine.*;
 
-import java.util.*;
 import picocli.CommandLine;
 import utils.*;
 import utils.Nyu;
@@ -53,15 +52,25 @@ public final class Mixins {
     }
   }
 
-  public static final class Term {
+  public static final class TermOption {
     @Spec private CommandLine.Model.CommandSpec spec;
 
     @Option(
         names = "--term",
         description =
-            "example: fa2020, where: fa=Fall, ja=January, sp=Spring, su=Summer",
-        required = true, converter = TermConverter.class)
+            "example: fa2021, where: fa=Fall, ja=January, sp=Spring, su=Summer",
+        required = true)
     public Nyu.Term term;
+  }
+
+  public static final class TermArgument {
+    @Spec private CommandLine.Model.CommandSpec spec;
+
+    @Parameters(
+        paramLabel = "TERMS",
+        description =
+            "example: fa2021, where: fa=Fall, ja=January, sp=Spring, su=Summer")
+    public Nyu.Term[] terms;
   }
 
   public static class TermConverter implements ITypeConverter<Nyu.Term> {

--- a/src/main/java/cli/Scrape.java
+++ b/src/main/java/cli/Scrape.java
@@ -2,8 +2,6 @@ package cli;
 
 import static picocli.CommandLine.*;
 
-import java.io.IOException;
-import java.util.concurrent.ExecutionException;
 import me.tongfei.progressbar.ProgressBar;
 import org.slf4j.*;
 import picocli.CommandLine;
@@ -35,7 +33,7 @@ public class Scrape implements Runnable {
            header = "Scrape the PeopleSoft Class Search",
            description = "Scrape the PeopleSoft Class Search for a term")
   public void
-  term(@Mixin Mixins.Term termMixin, @Mixin Mixins.OutputFile outputFileMixin) {
+  term(@Mixin Mixins.TermOption termMixin, @Mixin Mixins.OutputFile outputFileMixin) {
     long start = System.nanoTime();
 
     Nyu.Term term = termMixin.term;
@@ -72,7 +70,7 @@ public class Scrape implements Runnable {
            header = "Scrape the PeopleSoft Class Search",
            description = "Scrape the PeopleSoft Class Search for a term")
   public void
-  subject(@Mixin Mixins.Term termMixin,
+  subject(@Mixin Mixins.TermOption termMixin,
           @Mixin Mixins.OutputFile outputFileMixin,
           @Parameters(index = "0", paramLabel = "SUBJECT",
                       description = "A subject code like MATH-UA")
@@ -95,7 +93,7 @@ public class Scrape implements Runnable {
            header = "Scrape the PeopleSoft Class Search",
            description = "Scrape the PeopleSoft Class Search for a term")
   public void
-  schools(@Mixin Mixins.Term termMixin,
+  schools(@Mixin Mixins.TermOption termMixin,
           @Mixin Mixins.OutputFile outputFileMixin) {
     long start = System.nanoTime();
 

--- a/src/main/java/database/Migrations.java
+++ b/src/main/java/database/Migrations.java
@@ -7,7 +7,7 @@ import java.util.*;
 import org.slf4j.*;
 import utils.Utils;
 
-public final class Migrations {
+final class Migrations {
   private static Logger logger = LoggerFactory.getLogger("database.Migrations");
 
   private static final String SCHEMA_QUERY =


### PR DESCRIPTION
- Move migration runs to the initializer of `GetConnection.HolderClass`
- Add CI/CD runner for all the tests
- Upgrade Java version to JDK 19
- Term Mixins separated into `TermOptions` and `TermArg`
- Term class converter registered globally instead of on individual systems
- populate allows passing in multiple terms through `@Parameters`