### PR TITLE
Renaming Jobs, adding "Java - Typecheck"

### DIFF
--- a/.github/workflows/java-compile.yml
+++ b/.github/workflows/java-compile.yml
@@ -1,0 +1,33 @@
+name: Java - Typecheck
+
+on:
+  push:
+
+permissions:
+  contents: read
+
+jobs:
+  java-compile:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Project
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+
+    - name: Set up Node + Yarn
+      uses: actions/setup-node@v3
+      with:
+        cache: 'yarn'
+
+    - name: Set up Java
+      uses: actions/setup-java@v3
+      with:
+        java-version: '19'
+        distribution: 'temurin'
+        cache: 'gradle'
+
+    - name: Build JAR file
+      run: |
+        yarn gradle jar

--- a/.github/workflows/java-formatting.yml
+++ b/.github/workflows/java-formatting.yml
@@ -1,4 +1,4 @@
-name: Check Java Formatting
+name: Java - Check Formatting
 
 on:
   push:

--- a/.github/workflows/java-formatting.yml
+++ b/.github/workflows/java-formatting.yml
@@ -2,9 +2,6 @@ name: Java - Check Formatting
 
 on:
   push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
 
 jobs:
   java-linter:

--- a/.github/workflows/java-test.yml
+++ b/.github/workflows/java-test.yml
@@ -1,4 +1,4 @@
-name: Test Java Code
+name: Java - Run Tests
 
 on:
   push:

--- a/.github/workflows/js-formatting.yml
+++ b/.github/workflows/js-formatting.yml
@@ -2,9 +2,6 @@ name: JS - Check Formatting
 
 on:
   push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
 
 jobs:
   js-linter:

--- a/.github/workflows/js-formatting.yml
+++ b/.github/workflows/js-formatting.yml
@@ -1,4 +1,4 @@
-name: Check JS Formatting
+name: JS - Check Formatting
 
 on:
   push:


### PR DESCRIPTION
- Rename checker workflow jobs to start with language name then a dash
- Add "Java - Typecheck"
- Remove `on.pull_request` and remove branch restrictions to `on.push`