### PR TITLE
Added placeholder values for schools filled in when doing `ScrapeSchedgeV1`

### DIFF
--- a/src/main/java/scraping/ScrapeSchedgeV1.java
+++ b/src/main/java/scraping/ScrapeSchedgeV1.java
@@ -28,13 +28,15 @@ public final class ScrapeSchedgeV1 {
     programs.put("CD", "College of Dentistry Continuing Education");
     programs.put("DN", "College of Dentistry - Graduate");
 
-    // @TODO: what the hell are these
-    programs.put("ND", "");
-    programs.put("NY", "");
-    programs.put("NB", "");
-    programs.put("NE", "");
-    programs.put("NH", "");
-    programs.put("NI", "");
+    // @TODO: what the hell are these - below are educated guesses
+    programs.put("ND", "Non-Credit College of Dentistry");
+    programs.put("NY", "Non-Credit Tandon School of Engineering");
+    programs.put("NB", "Non-Credit Leonard N. Stern School of Business");
+    programs.put(
+        "NE",
+        "Non-Credit Steinhardt School of Culture, Education, and Human Development");
+    programs.put("NH", "Non-Credit NYU Abu Dhabi");
+    programs.put("NI", "Non-Credit NYU Shanghai");
 
     missingPrograms = programs;
   }


### PR DESCRIPTION
Used the model of

- `UT` -> `Tisch School of Arts`
- `NT -> `Non-Credit Tisch School of Arts`

to fill in `NB`, `NY`, `NI`, etc. etc.

A note, `UI` is one of the names for `NYU Shanghai`