### PR TITLE
Refactor Event handlers for ScrapeEvent

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
     "format": "prettier --no-color --write \"src/{pages/**/,components/**/,}*.{js,jsx,ts,tsx,module.css}\"",
     "dev": "next dev -p 9100",
     "export": "next build && next export -o src/main/resources/next",
-    "ci-test": "git commit --allow-empty -m \"RUN_TEST\" && git push -u origin HEAD",
     "lint": "next lint",
     "gradle": "node src/gradlew.js",
     "exec": "docker-compose exec",

--- a/src/main/java/cli/Database.java
+++ b/src/main/java/cli/Database.java
@@ -51,23 +51,7 @@ public class Database implements Runnable {
     GetConnection.withConnection(conn -> {
       for (var term : termMixin.terms) {
         try (ProgressBar bar = new ProgressBar("Scrape " + term.json(), -1)) {
-          ScrapeTerm.scrapeTerm(conn, term, e -> {
-            switch (e.kind) {
-            case MESSAGE:
-            case SUBJECT_START:
-              bar.setExtraMessage(e.message);
-              break;
-            case WARNING:
-              logger.warn(e.message);
-              break;
-            case PROGRESS:
-              bar.stepBy(e.value);
-              break;
-            case HINT_CHANGE:
-              bar.maxHint(e.value);
-              break;
-            }
-          });
+          ScrapeTerm.scrapeTerm(conn, term, ScrapeEvent.cli(logger, bar));
         }
       }
     });

--- a/src/main/java/cli/Scrape.java
+++ b/src/main/java/cli/Scrape.java
@@ -5,8 +5,7 @@ import static picocli.CommandLine.*;
 import me.tongfei.progressbar.ProgressBar;
 import org.slf4j.*;
 import picocli.CommandLine;
-import scraping.PeopleSoftClassSearch;
-import scraping.ScrapeEvent;
+import scraping.*;
 import utils.Nyu;
 
 /*

--- a/src/main/java/cli/Scrape.java
+++ b/src/main/java/cli/Scrape.java
@@ -6,6 +6,7 @@ import me.tongfei.progressbar.ProgressBar;
 import org.slf4j.*;
 import picocli.CommandLine;
 import scraping.PeopleSoftClassSearch;
+import scraping.ScrapeEvent;
 import utils.Nyu;
 
 /*
@@ -39,23 +40,8 @@ public class Scrape implements Runnable {
 
     Nyu.Term term = termMixin.term;
     try (ProgressBar bar = new ProgressBar("Scrape", -1)) {
-      var courses = PeopleSoftClassSearch.scrapeTerm(term, e -> {
-        switch (e.kind) {
-        case MESSAGE:
-        case SUBJECT_START:
-          bar.setExtraMessage(e.message);
-          break;
-        case WARNING:
-          logger.warn(e.message);
-          break;
-        case PROGRESS:
-          bar.stepBy(e.value);
-          break;
-        case HINT_CHANGE:
-          bar.maxHint(e.value);
-          break;
-        }
-      });
+      var courses =
+          PeopleSoftClassSearch.scrapeTerm(term, ScrapeEvent.cli(logger, bar));
       outputFileMixin.writeOutput(courses);
     }
 

--- a/src/main/java/scraping/ScrapeEvent.java
+++ b/src/main/java/scraping/ScrapeEvent.java
@@ -1,5 +1,9 @@
 package scraping;
 
+import java.util.function.*;
+import me.tongfei.progressbar.*;
+import org.slf4j.*;
+
 /* Real fucking stupid implementation of whatever you desire
  * to call this. Event listening, observer pattern, whatever.
  *
@@ -46,5 +50,25 @@ public final class ScrapeEvent {
 
   static ScrapeEvent hintChange(int hint) {
     return new ScrapeEvent(Kind.HINT_CHANGE, null, null, hint);
+  }
+
+  public static Consumer<ScrapeEvent> cli(Logger logger, ProgressBar bar) {
+    return e -> {
+      switch (e.kind) {
+      case MESSAGE:
+      case SUBJECT_START:
+        bar.setExtraMessage(e.message);
+        break;
+      case WARNING:
+        logger.warn(e.message);
+        break;
+      case PROGRESS:
+        bar.stepBy(e.value);
+        break;
+      case HINT_CHANGE:
+        bar.maxHint(e.value);
+        break;
+      }
+    };
   }
 }


### PR DESCRIPTION
- Create `ScrapeEvent.cli()` which returns a `Consumer` which outputs to `Logger` and `ProgressBar`
- Remove `yarn ci-test` since tests always run now