### PR TITLE
Add `platform: linux/amd64` to schedge service in docker compose file

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          java-version: '19'
+          java-version: '17'
           distribution: 'adopt'
           cache: 'gradle'
 

--- a/.github/workflows/java-compile.yml
+++ b/.github/workflows/java-compile.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Java
       uses: actions/setup-java@v3
       with:
-        java-version: '17'
+        java-version: '19'
         distribution: 'temurin'
         cache: 'gradle'
 

--- a/.github/workflows/java-compile.yml
+++ b/.github/workflows/java-compile.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Java
       uses: actions/setup-java@v3
       with:
-        java-version: '19'
+        java-version: '17'
         distribution: 'temurin'
         cache: 'gradle'
 

--- a/.github/workflows/java-test.yml
+++ b/.github/workflows/java-test.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Set up Java
       uses: actions/setup-java@v3
       with:
-        java-version: '19'
+        java-version: '17'
         distribution: 'temurin'
         cache: 'gradle'
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,8 @@ mainClassName = 'cli.Main'
 // }
 
 java {
-  sourceCompatibility = '11'
-  targetCompatibility = '11'
+  sourceCompatibility = 11
+  targetCompatibility = 11
 }
 
 tasks.named('wrapper') {

--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,6 @@ plugins {
 }
 
 mainClassName = 'cli.Main'
-sourceCompatibility = '11'
-targetCompatibility = '11'
 
 // def getenv = { String env_val, default_val ->
 //   ext.val = System.getenv(env_val)
@@ -15,10 +13,14 @@ targetCompatibility = '11'
 //   } else return ext.val
 // }
 
+java {
+  sourceCompatibility = '11'
+  targetCompatibility = '11'
+}
+
 tasks.named('wrapper') {
   jarFile = "${project.projectDir}/src/build/gradle/gradle-wrapper.jar"
 }
-
 
 tasks.withType(JavaCompile) {
   options.compilerArgs << "-Xlint:unchecked"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - "./.build/postgres:/var/lib/postgresql/data"
 
   schedge:
+    platform: linux/amd64
     build:
       context: .
       dockerfile: ./src/build/docker/Dockerfile


### PR DESCRIPTION
Eclipse temurin doesn't have an image for aarch64, which breaks M1 machines.

Also have to fiddle with some Java versions, for reasons that I do not understand.