### PR TITLE
Improve shutdown speed of schedge container

### DIFF
--- a/src/build/docker/entrypoint.sh
+++ b/src/build/docker/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 # This script makes it easier to run commands in the docker compose
-java -Xmx1G -Djdk.httpclient.allowRestrictedHeaders=host,connection \
-  -jar /app/schedge.jar $@
+exec java -Xmx1G -Djdk.httpclient.allowRestrictedHeaders=host,connection \
+  -jar /app/schedge.jar "$@"

--- a/src/main/java/api/App.java
+++ b/src/main/java/api/App.java
@@ -73,7 +73,7 @@ public class App {
     }
   }
 
-  public static final int PORT = 4358;
+  public static final int PORT = Utils.getEnvDefault("SCHEDGE_PORT", 4358);
   public static final String DESCR_TEMPLATE = """
     Schedge is an API to NYU's course catalog. Please note that
     <b>this API is a beta build currently under active development

--- a/src/main/java/utils/Utils.java
+++ b/src/main/java/utils/Utils.java
@@ -8,6 +8,8 @@ import java.time.*;
 import java.util.*;
 import java.util.stream.*;
 
+import static utils.Try.tcIgnore;
+
 public final class Utils {
   private static BufferedReader inReader =
       new BufferedReader(new InputStreamReader(System.in));
@@ -145,8 +147,16 @@ public final class Utils {
     String value = System.getenv(name);
     if (value == null) {
       return defaultValue;
-    } else
-      return value;
+    }
+    return value;
+  }
+
+  public static int getEnvDefault(String name, int defaultValue) {
+    Integer value = tcIgnore(() -> Integer.parseInt(System.getenv(name)));
+    if (value == null) {
+      return defaultValue;
+    }
+    return value;
   }
 
   static class NullWrapper {

--- a/src/main/java/utils/Utils.java
+++ b/src/main/java/utils/Utils.java
@@ -1,6 +1,6 @@
 package utils;
 
-import static utils.Try.tcIgnore;
+import static utils.Try.*;
 
 import java.io.*;
 import java.net.*;

--- a/src/main/java/utils/Utils.java
+++ b/src/main/java/utils/Utils.java
@@ -1,5 +1,7 @@
 package utils;
 
+import static utils.Try.tcIgnore;
+
 import java.io.*;
 import java.net.*;
 import java.nio.file.*;
@@ -7,8 +9,6 @@ import java.sql.*;
 import java.time.*;
 import java.util.*;
 import java.util.stream.*;
-
-import static utils.Try.tcIgnore;
 
 public final class Utils {
   private static BufferedReader inReader =

--- a/src/main/java/utils/Utils.java
+++ b/src/main/java/utils/Utils.java
@@ -1,7 +1,5 @@
 package utils;
 
-import static utils.Try.*;
-
 import java.io.*;
 import java.net.*;
 import java.nio.file.*;
@@ -152,7 +150,7 @@ public final class Utils {
   }
 
   public static int getEnvDefault(String name, int defaultValue) {
-    Integer value = tcIgnore(() -> Integer.parseInt(System.getenv(name)));
+    Integer value = Try.tcIgnore(() -> Integer.parseInt(System.getenv(name)));
     if (value == null) {
       return defaultValue;
     }


### PR DESCRIPTION
Today I learned that bash is even dumber than I thought.

The `entrypoint.sh` script wasn't using `exec`, so the `SIGTERM` that Docker sends to the container was being eaten by `bash` and then nothing was happening, or potentially `bash` translated the signal to another signal which was then ignored. Not sure, don't really care, this fixes the problem.

Resource: https://vsupalov.com/docker-compose-stop-slow/

Also, a few misc. improvements that were written while debugging this problem:
- Added integer version of `getEnvDefault`
- Added `SCHEDGE_PORT` to override the port with an environment variable