### PR TITLE
Upgrade Javalin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,10 @@ repositories {
 }
 
 dependencies {
+  def javalin = "5.3.0"
+
   annotationProcessor(
-    "io.javalin.community.openapi:openapi-annotation-processor:5.3.0"
+    "io.javalin.community.openapi:openapi-annotation-processor:$javalin"
   )
 
   testImplementation(
@@ -60,9 +62,9 @@ dependencies {
     "com.fasterxml.jackson.core:jackson-annotations:2.7.4",
 
     // Web server framework and documentation
-    "io.javalin:javalin:5.3.0",
+    "io.javalin:javalin:$javalin",
     // for /openapi route with JSON scheme
-    "io.javalin.community.openapi:javalin-openapi-plugin:5.3.0",
+    "io.javalin.community.openapi:javalin-openapi-plugin:$javalin",
   )
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ repositories {
 
 dependencies {
   annotationProcessor(
-    "io.javalin.community.openapi:openapi-annotation-processor:5.1.0"
+    "io.javalin.community.openapi:openapi-annotation-processor:5.3.0"
   )
 
   testImplementation(
@@ -60,9 +60,9 @@ dependencies {
     "com.fasterxml.jackson.core:jackson-annotations:2.7.4",
 
     // Web server framework and documentation
-    "io.javalin:javalin:5.1.4",
+    "io.javalin:javalin:5.3.0",
     // for /openapi route with JSON scheme
-    "io.javalin.community.openapi:javalin-openapi-plugin:5.1.0",
+    "io.javalin.community.openapi:javalin-openapi-plugin:5.3.0",
   )
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -38,8 +38,8 @@ dependencies {
   )
 
   testImplementation(
-    'junit:junit:4.13.2',
-    'io.javalin:javalin-testtools:5.1.3',
+    "junit:junit:4.13.2",
+    "io.javalin:javalin-testtools:$javalin",
   )
 
   implementation(

--- a/src/main/java/api/App.java
+++ b/src/main/java/api/App.java
@@ -86,15 +86,16 @@ public class App {
 
       var description = String.format(DESCR_TEMPLATE, Health.BUILD_VERSION);
 
-      var info = new OpenApiInfo();
-      info.setVersion("2.0.0 beta");
-      info.setTitle("Schedge");
-      info.setDescription(description);
+      var openApiConfig = new OpenApiPluginConfiguration();
+      openApiConfig.withDocumentationPath("/api/swagger.json");
+      openApiConfig.withDefinitionConfiguration((version, definition) -> {
+        definition.withOpenApiInfo(info -> {
+          info.setVersion("2.0.0 beta");
+          info.setTitle("Schedge");
+          info.setDescription(description);
+        });
+      });
 
-      var jsonPath = "/api/swagger.json";
-      var openApiConfig = new OpenApiConfiguration();
-      openApiConfig.setInfo(info);
-      openApiConfig.setDocumentationPath(jsonPath);
       config.plugins.register(new OpenApiPlugin(openApiConfig));
 
       config.staticFiles.add(staticFiles -> { // NextJS UI


### PR DESCRIPTION
Javalin 5.2.0+ allows you to use micrometer for metrics. This PR upgrades to 5.3.0 to allow using micrometer in the future.