### PR TITLE
Switch from `ci-populate` to `test-populate`

### DIFF
--- a/.github/workflows/java-test.yml
+++ b/.github/workflows/java-test.yml
@@ -77,12 +77,7 @@ jobs:
       run: >
         java -Xmx1G -Djdk.httpclient.allowRestrictedHeaders=host,connection
         -jar build/libs/schedge.jar
-        db ci-populate
-        sp2021/CSCI-UA sp2021/SCA-UA_1 sp2021/MATH-UA sp2021/DS-UA
-        fa2022/CSCI-UA
-        sp2023/ITPG-GT sp2023/MASY1-GC sp2023/CSCI-UA sp2023/DM-UY sp2023/CS-UY
-        sp2023/INTG1-GC sp2023/PUBB1-GC sp2023/URPL-GP sp2023/DHSS-GA sp2023/OART-UT
-        sp2023/OART-GT sp2023/COART-UT sp2023/IMNY-UT sp2023/PWRT1-GC
+        db test-populate
 
     - name: Test Code
       id: test-code

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -23,8 +23,8 @@ You'll need to install a few applications to contribute to this project:
   The project is written in Java, so you'll probably need to install a Java
   Development Kit (JDK) in order to build and run it.
 
-  **NOTE:** Please use at least version 11 and at most version 18. This project
-  uses Java 11 features, so at least JDK 11 is required, but Gradle doesn't
+  **NOTE:** Please use at least version 17 and at most version 18. This project
+  uses Java 17 features, so at least JDK 17 is required, but Gradle doesn't
   seem to support anything later than 18 right now, so you will not be able
   to build code if you install JDK 19.
 - [NodeJS](https://heynode.com/tutorial/install-nodejs-locally-nvm/) and [Yarn](https://yarnpkg.com/getting-started/install) -

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -64,15 +64,9 @@ You'll need to install a few applications to contribute to this project:
   Run `psql` on the local database
 
 ## Testing
-- `yarn test` will test the backend; before running tests, please scrape the
-  following terms:
-
-  - `sp2021`
-  - `fa2022`
-  - `sp2023`
-
-  You can use `yarn schedge db populate INSERT_TERM_HERE` to scrape a specific
-  term from production.
+- `yarn test` will test the backend; before running tests, please run the
+  command `yarn schedge db test-populate` in order to populate the database with
+  the necessary test data.
 
 ### Comment Annotations
 The codebase uses the following annotations in the comments:

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "node src/gradlew.js test",
     "start": "node src/gradlew.js composeUp",
     "stop": "docker-compose down",
-    "compile": "node src/gradlew.js check",
+    "compile": "node src/gradlew.js jar",
     "schedge": "docker-compose exec schedge schedge",
     "psql": "docker-compose exec postgres psql --dbname=postgres --host=localhost --port=5432 --username=postgres"
   },

--- a/src/main/java/cli/Database.java
+++ b/src/main/java/cli/Database.java
@@ -108,9 +108,9 @@ public class Database implements Runnable {
   static {
     var s = new HashMap<String, Optional<List<String>>>();
 
-    s.put("sp2021", Optional.of(Arrays.asList("csci-ua", "sca-ua_1", "math-ua", "ds-ua")));
+    s.put("sp2021", Optional.of(Arrays.asList("CSCI-UA", "SCA-UA_1", "MATH-UA", "DS-UA")));
 
-    s.put("fa2022", Optional.of(Arrays.asList("csci-ua")));
+    s.put("fa2022", Optional.of(Arrays.asList("CSCI-UA")));
 
     s.put(
         "sp2023",

--- a/src/main/java/cli/Database.java
+++ b/src/main/java/cli/Database.java
@@ -79,7 +79,8 @@ public class Database implements Runnable {
           boolean useV1,
       @Option(
               names = {"--v2"},
-              description = "scrape v2")
+              description = "scrape v2",
+              defaultValue = "true")
           boolean useV2) {
     long start = System.nanoTime();
 
@@ -102,44 +103,50 @@ public class Database implements Runnable {
     logger.info("{} seconds", duration);
   }
 
+  private static final HashMap<String, Optional<List<String>>> subjects;
+
+  static {
+    var s = new HashMap<String, Optional<List<String>>>();
+
+    s.put("sp2021", Optional.of(Arrays.asList("csci-ua", "sca-ua_1", "math-ua", "ds-ua")));
+
+    s.put("fa2022", Optional.of(Arrays.asList("csci-ua")));
+
+    s.put(
+        "sp2023",
+        Optional.of(
+            Arrays.asList(
+                "ITPG-GT",
+                "MASY1-GC",
+                "CSCI-UA",
+                "DM-UY",
+                "CS-UY",
+                "INTG1-GC",
+                "PUBB1-GC",
+                "URPL-GP",
+                "DHSS-GA",
+                "OART-UT",
+                "OART-GT",
+                "COART-UT",
+                "IMNY-UT",
+                "PWRT1-GC")));
+
+    subjects = s;
+  }
+
   @Command(
-      name = "ci-populate",
+      name = "test-populate",
       description =
-          "Populate the database for CI by scraping the existing production "
+          "Populate the database for testing by scraping the existing production "
               + "Schedge instance.\n")
-  public void ciPopulate(@Parameters(paramLabel = "SUBJECT_STRINGS") String[] subjectStrings) {
+  public void testPopulate() {
     var start = System.nanoTime();
 
     GetConnection.forceInit();
 
-    var FULL_TERM = new ArrayList<String>();
-    var map = new HashMap<String, ArrayList<String>>();
-
-    for (var subjectAndTermString : subjectStrings) {
-      var parts = subjectAndTermString.split("/", 2);
-      var termString = parts[0];
-
-      if (parts.length == 1) {
-        map.put(termString, FULL_TERM);
-        logger.debug("Adding full term for {}", termString);
-        continue;
-      }
-
-      var subjectString = parts[1];
-      logger.debug("Adding term={}, subjectString={}", termString, subjectString);
-
-      var subjects = map.computeIfAbsent(termString, k -> new ArrayList<>());
-      if (subjects != FULL_TERM) subjects.add(subjectString);
-    }
-
-    for (var pair : map.entrySet()) {
+    for (var pair : subjects.entrySet()) {
       var term = Term.fromString(pair.getKey());
-      var subjectsValue = pair.getValue();
-      if (subjectsValue == FULL_TERM) {
-        subjectsValue = null;
-      }
-
-      var subjects = subjectsValue;
+      var subjects = pair.getValue();
 
       logger.info("Fetching term={}", term.json());
 
@@ -147,9 +154,7 @@ public class Database implements Runnable {
           conn -> {
             var termStart = System.nanoTime();
 
-            var result =
-                ScrapeSchedgeV2.scrapeFromSchedge(
-                    term, Optional.of(subjects), ScrapeEvent.log(logger));
+            var result = ScrapeSchedgeV2.scrapeFromSchedge(term, subjects, ScrapeEvent.log(logger));
 
             var fetchEnd = System.nanoTime();
             var duration = (fetchEnd - termStart) / 1000000000.0;


### PR DESCRIPTION
- `ci-populate` is a bit weird; the tests are run during development too potentially, so might as well make it possible to scrape the test data in development too.
- Changes `compile` to not use `check` since it can be confusing
- Changes the contributing guide to reflect the correct Java version