### PR TITLE
add  NYU Course Schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ a scrape afterwards, Schedge won't pick it up.
 ## Apps that use Schedge
 Here's a list of apps that use this API:
 
+* https://nyu.myschedule.xyz/#/ NYU Course Schedule, support fall 2023 courses.
+
 - https://rate-my-classes-pro.netlify.app | https://apple.co/3AduK8G (repo at https://github.com/zhumingcheng697/Rate-My-Classes-Pro )
 - https://courses.torchnyu.com (repo at https://github.com/NicholasLYang/courses )
 - https://bobcatsearch.com (repo at https://github.com/EthanPrintz/bobcat-search )


### PR DESCRIPTION
I'm a new student at Tandon and I developed a NYU Course Schedule tool. Here are some of its features:

A better UI interface, making course selection and checking easier.
Access your course information anytime and anywhere, supported on both PC and mobile devices.
Share your course schedule with classmates, friends or relatives.
One-click access to RateMyProfessor.
no ads, login registration or other unnecessary features.

You can try the tool here: https://nyu.myschedule.xyz/#/ Feel free to recommend it to other students or provide any feedback or suggestions.